### PR TITLE
Switch to Symfony 4 with Postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
     db:
@@ -22,9 +22,8 @@ services:
         build: nginx
         ports:
             - 80:80
-        volumes_from:
-            - php
         volumes:
+            - ${SYMFONY_APP_PATH}:/var/www/symfony
             - ./logs/nginx/:/var/log/nginx
     elk:
         image: willdurand/elk
@@ -33,6 +32,4 @@ services:
         volumes:
             - ./elk/logstash:/etc/logstash
             - ./elk/logstash/patterns:/opt/logstash/patterns
-        volumes_from:
-            - php
-            - nginx
+            - ./logs:/var/log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,11 @@ version: '3'
 
 services:
     db:
-        image: mysql
+        image: postgres
         volumes:
-            - "./.data/db:/var/lib/mysql"
+            - "./.data/db:/var/lib/postgresql"
         environment:
-            MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-            MYSQL_DATABASE: ${MYSQL_DATABASE}
-            MYSQL_USER: ${MYSQL_USER}
-            MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+            POSTGRES_PASSWORD: postgres
     php:
         build:
             context: php7-fpm

--- a/nginx/symfony.conf
+++ b/nginx/symfony.conf
@@ -1,21 +1,11 @@
 server {
     server_name symfony.local;
-    root /var/www/symfony/web;
+    root /var/www/symfony/public;
 
     location / {
-        try_files $uri @rewriteapp;
-    }
-
-    location @rewriteapp {
-        rewrite ^(.*)$ /app.php/$1 last;
-    }
-
-    location ~ ^/(app|app_dev|config)\.php(/|$) {
-        fastcgi_pass php-upstream;
-        fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param HTTPS off;
+        fastcgi_param SCRIPT_FILENAME $document_root/index.php;
+        fastcgi_pass php-upstream;
     }
 
     error_log /var/log/nginx/symfony_error.log;

--- a/php7-fpm/Dockerfile
+++ b/php7-fpm/Dockerfile
@@ -7,7 +7,8 @@ MAINTAINER Maxence POUTORD <maxence.poutord@gmail.com>
 RUN apt-get update && apt-get install -y \
     openssl \
     git \
-    unzip
+    unzip \
+    libpq-dev
 
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
@@ -19,8 +20,7 @@ RUN printf '[PHP]\ndate.timezone = "%s"\n', ${TIMEZONE} > /usr/local/etc/php/con
 RUN "date"
 
 # Type docker-php-ext-install to see available extensions
-RUN docker-php-ext-install pdo pdo_mysql
-
+RUN docker-php-ext-install -j$(nproc) pdo pgsql pdo_pgsql
 
 # install xdebug
 RUN pecl install xdebug


### PR DESCRIPTION
Updated nginx config to work with symfony 4 (was symfony 3 previously). Nginx now just proxies everything through PHP, as we don't need to server any files here, just a REST API.
Postgres is now used instead of mysql.
Also updated docker-compose format.